### PR TITLE
feat: Create directories if path contains `/`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ mod tests {
     fn test_touch_creates_file() {
         let test_path = format!("{}.txt", std::module_path!());
         assert!(!Path::new(&test_path).exists());
-        touch(&test_path).unwrap();
+        assert!(touch(&test_path).is_ok());
         assert!(Path::new(&test_path).exists());
         fs::remove_file(test_path).unwrap();
     }
@@ -62,7 +62,7 @@ mod tests {
         let test_path = format!("{}.txt", std::module_path!());
         fs::File::create(&test_path).unwrap();
         thread::sleep(Duration::from_secs(1));
-        touch(&test_path).unwrap();
+        assert!(touch(&test_path).is_ok());
         let metadata = metadata(&test_path).unwrap();
         let modified_time = FileTime::from_last_modification_time(&metadata);
         assert_eq!(modified_time.unix_seconds(), FileTime::now().unix_seconds());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use filetime::{set_file_times, FileTime};
 use std::fs::{create_dir_all, OpenOptions};
 use std::io::Result;
+use std::path::Path;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -12,15 +13,22 @@ struct Args {
 fn main() {
     let args = Args::parse();
     for file in args.files {
+        // Create directory if it contains directories
+        if file.contains('/') {
+            let path = Path::new(&file);
+            if let Some(parent) = path.parent() {
+                match create_dir_all(parent) {
+                    Ok(_) => println!("Directory({}) created successfully", parent.display()),
+                    Err(e) => println!("Error creating directory({}): {}", parent.display(), e),
+                }
+            }
+        }
+
+        // Create file
         match touch(file.as_str()) {
             Ok(_) => println!("File created successfully"),
-            Err(e) => println!("Error creating file: {}", e),
+            Err(e) => println!("Error creating file({}): {}", file, e),
         }
-    }
-
-    match create_dir_all("my_directory") {
-        Ok(_) => println!("Directory created successfully"),
-        Err(e) => println!("Error creating directory: {}", e),
     }
 }
 


### PR DESCRIPTION
Create a directory if path contains `/`.

### Example

```console
$ cargo run -- a/b/c a/x
   Compiling torch v0.1.0 (/Users/toshimaru/src/github.com/toshimaru/torch)
    Finished dev [unoptimized + debuginfo] target(s) in 0.53s
     Running `target/debug/torch a/b/c a/x`
Directory(a/b) created successfully
File created successfully
Directory(a) created successfully
File created successfully

$ tree a
a
├── b
│   └── c
└── x

2 directories, 2 files
```