### PR TITLE
Add `arch64-unknown-linux-gnu` to targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torch-cmd"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Toshimaru <me@toshimaru.net>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
 tap = "toshimaru/homebrew-torch"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Publish jobs to run in CI


### PR DESCRIPTION
After the initial release ([v0.1.0](https://github.com/toshimaru/torch/releases/tag/v0.1.0)), I tried the shell installation and got an error:

```console
# curl --proto '=https' --tlsv1.2 -LsSf https://github.com/toshimaru/torch/releases/download/v0.1.0/torch-cmd-installer.sh | sh
ERROR: there isn't a package for aarch64-unknown-linux-gnu
```

Therefore, add `aarch64-unknown-linux-gnu` to the build targets.