### PR TITLE
fix: Use custom-runners for `aarch64-unknown-linux-gnu` build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,11 @@ installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
 tap = "toshimaru/homebrew-torch"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+
+[workspace.metadata.dist.github-custom-runners]
+aarch64-unknown-linux-gnu = "buildjet-2vcpu-ubuntu-2204-arm"


### PR DESCRIPTION
follows #11.

ref. https://github.com/axodotdev/cargo-dist/commit/60f5d137412afa9d69e81fa203f04794f78b859f