### PR TITLE
Replace rust-toolchain action with actions-rust-lang alternative

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo build --verbose
       - run: cargo test


### PR DESCRIPTION
This change replaces `dtolnay/rust-toolchain@stable` with `actions-rust-lang/setup-rust-toolchain@v1` in `.github/workflows/test.yml`. 

`actions-rust-lang/setup-rust-toolchain` is a popular community-maintained alternative that offers several advantages:
- Built-in caching (via integration with `Swatinem/rust-cache`).
- Automatic setup of Problem Matchers for cargo, clippy, and rustfmt output.
- Active maintenance and alignment with current Rust ecosystem best practices.

The replacement maintains the same default behavior (using the stable toolchain) while providing improved CI performance and developer feedback.

---
*PR created automatically by Jules for task [16528175377717808811](https://jules.google.com/task/16528175377717808811) started by @toshimaru*