### PR TITLE
ci: add lint job with clippy and rustfmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,13 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo build --verbose
       - run: cargo test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -16,7 +16,7 @@ jobs:
       - run: cargo test
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,11 @@ fn mkdir(dir: &Path) -> Result<()> {
 
 fn touch(path: &Path) -> Result<()> {
     if !path.exists() {
-        OpenOptions::new().create(true).write(true).open(path)?;
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
     }
     let now: FileTime = FileTime::now();
     set_file_times(path, now, now)?;


### PR DESCRIPTION
This pull request introduces a new linting workflow to the project's GitHub Actions and makes a small improvement to file creation logic in the `touch` function. The workflow addition helps enforce code quality, while the code change clarifies file creation behavior.

**Continuous Integration Improvements:**

* Added a `lint` job to `.github/workflows/test.yml` that runs `cargo fmt` and `cargo clippy` to ensure code formatting and linting checks are enforced in CI.
* Use ubuntu-slim image

**Code Quality and Behavior:**

* Updated the `touch` function in `src/main.rs` to explicitly set `.truncate(false)` when opening files, clarifying that existing files will not be truncated when touched.