### PR TITLE
deps: Bump Rust edition from 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "torch-cmd"
 version = "0.2.1"
-edition = "2021"
+edition = "2024"
 authors = ["Toshimaru <me@toshimaru.net>"]
 license = "MIT"
 description = "mkdir + touch command"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use filetime::{set_file_times, FileTime};
-use std::fs::{create_dir_all, OpenOptions};
+use filetime::{FileTime, set_file_times};
+use std::fs::{OpenOptions, create_dir_all};
 use std::io::Result;
 use std::path::Path;
 
@@ -77,7 +77,7 @@ fn touch(path: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use std::fs::metadata;
-    use std::fs::{remove_dir_all, remove_file, File};
+    use std::fs::{File, remove_dir_all, remove_file};
     use std::thread;
     use std::time::Duration;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ fn mkdir_touch(path: &str) -> bool {
     let p = Path::new(&path);
 
     // Create directory if it contains directories
-    if path.contains('/') {
-        if let Some(dir) = p.parent() {
+    if path.contains('/')
+        && let Some(dir) = p.parent() {
             match mkdir(dir) {
                 Ok(_) => {}
                 Err(e) => {
@@ -39,7 +39,6 @@ fn mkdir_touch(path: &str) -> bool {
                 }
             }
         }
-    }
 
     // Create file
     match touch(p) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,15 +30,16 @@ fn mkdir_touch(path: &str) -> bool {
 
     // Create directory if it contains directories
     if path.contains('/')
-        && let Some(dir) = p.parent() {
-            match mkdir(dir) {
-                Ok(_) => {}
-                Err(e) => {
-                    eprintln!("Error creating a directory({}): {}", dir.display(), e);
-                    return false;
-                }
+        && let Some(dir) = p.parent()
+    {
+        match mkdir(dir) {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Error creating a directory({}): {}", dir.display(), e);
+                return false;
             }
         }
+    }
 
     // Create file
     match touch(p) {


### PR DESCRIPTION
This pull request includes minor code improvements and updates to the project configuration. The main changes are focused on modernizing the Rust edition, improving code style, and cleaning up import ordering for better readability.

Project configuration:

* Updated the Rust edition in `Cargo.toml` from 2021 to 2024 to take advantage of the latest language features and improvements.

Code cleanup and style improvements:

* Reordered imports in `src/main.rs` for consistency and readability, including `filetime` and standard library imports. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL2-R3) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL80-R80)
* Refactored the directory creation logic in `mkdir_touch` to use the new let-else syntax, making the conditional more concise and idiomatic for Rust 2024.
* Removed an unnecessary closing brace after the directory creation logic in `mkdir_touch` for cleaner code structure.