### PR TITLE
feat: create directory when argument ends with trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Given one or more paths, `torch`:
 - creates missing parent directories
 - creates the target file if it does not exist
 - updates the access and modification times if it already exists
+- if a path ends with `/`, creates a directory (recursively) instead of a file
 - exits with a non-zero status if any path fails
 
 ## Usage
@@ -43,6 +44,7 @@ Examples:
 $ torch notes/today.md
 $ torch app/models/user.rb app/controllers/users_controller.rb
 $ torch tmp/output.log
+$ torch docs/guides/
 ```
 
 This command:

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,24 @@ fn main() {
 fn mkdir_touch(path: &str) -> bool {
     let p = Path::new(&path);
 
+    if path.ends_with('/') {
+        match mkdir(p) {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Error creating a directory({}): {}", p.display(), e);
+                return false;
+            }
+        }
+        match touch(p) {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Error creating a directory({}): {}", p.display(), e);
+                return false;
+            }
+        }
+        return true;
+    }
+
     // Create directory if it contains directories
     if path.contains('/')
         && let Some(dir) = p.parent()
@@ -168,6 +186,40 @@ mod tests {
         assert!(!mkdir_touch(&create_path));
         assert!(!Path::new(&create_path).exists());
         remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_mkdir_touch_trailing_slash_creates_directory() {
+        let path = "test_mkdir_touch_trailing_slash/";
+        remove_dir_all("test_mkdir_touch_trailing_slash").ok();
+        assert!(mkdir_touch(path));
+        let meta = metadata("test_mkdir_touch_trailing_slash").unwrap();
+        assert!(meta.is_dir());
+        remove_dir_all("test_mkdir_touch_trailing_slash").unwrap();
+    }
+
+    #[test]
+    fn test_mkdir_touch_trailing_slash_nested() {
+        let path = "test_mkdir_touch_trailing_slash_nested/a/b/c/";
+        remove_dir_all("test_mkdir_touch_trailing_slash_nested").ok();
+        assert!(mkdir_touch(path));
+        let meta = metadata("test_mkdir_touch_trailing_slash_nested/a/b/c").unwrap();
+        assert!(meta.is_dir());
+        remove_dir_all("test_mkdir_touch_trailing_slash_nested").unwrap();
+    }
+
+    #[test]
+    fn test_mkdir_touch_trailing_slash_existing_dir() {
+        let dir = "test_mkdir_touch_trailing_slash_existing_dir";
+        remove_dir_all(dir).ok();
+        create_dir_all(dir).unwrap();
+        thread::sleep(Duration::from_secs(1));
+        let path = format!("{}/", dir);
+        assert!(mkdir_touch(&path));
+        let metadata = metadata(dir).unwrap();
+        let modified_time = FileTime::from_last_modification_time(&metadata);
+        assert_eq!(modified_time.unix_seconds(), FileTime::now().unix_seconds());
+        remove_dir_all(dir).unwrap();
     }
 
     mod integration_tests {


### PR DESCRIPTION
## Summary

- Adds support for a trailing-slash convention: `torch foo/bar/` now creates `foo/bar` as a directory instead of a file
- Reuses the existing `mkdir` and `touch` helpers — no new helpers added
- Detection is done on the raw input string (`ends_with('/')`) before `Path` strips the trailing slash

## Test plan

- [ ] 3 new unit tests cover: creating a new directory, nested directories, and timestamp refresh on an existing directory
- [ ] All existing tests continue to pass
- [ ] `cargo clippy` and `cargo fmt --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)