### PR TITLE
refactor: Refactor mkdir_touch parent directory handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 }
 
 fn mkdir_touch(path: &str) -> bool {
-    let p = Path::new(&path);
+    let p = Path::new(path);
 
     // Create directory if it contains directories
     if path.contains('/')

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ fn mkdir_touch(path: &str) -> bool {
     let p = Path::new(path);
 
     // Create parent directories
-    if path.contains('/')
-        && let Some(dir) = p.parent()
+    if let Some(dir) = p.parent()
+        && !dir.as_os_str().is_empty()
         && let Err(e) = mkdir(dir)
     {
         eprintln!("Error creating a directory({}): {}", dir.display(), e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,26 +26,19 @@ fn main() {
 fn mkdir_touch(path: &str) -> bool {
     let p = Path::new(path);
 
-    // Create directory if it contains directories
+    // Create parent directories
     if path.contains('/')
         && let Some(dir) = p.parent()
+        && let Err(e) = mkdir(dir)
     {
-        match mkdir(dir) {
-            Ok(_) => {}
-            Err(e) => {
-                eprintln!("Error creating a directory({}): {}", dir.display(), e);
-                return false;
-            }
-        }
+        eprintln!("Error creating a directory({}): {}", dir.display(), e);
+        return false;
     }
 
-    // Create file
-    match touch(p) {
-        Ok(_) => {}
-        Err(e) => {
-            eprintln!("Error creating a file({}): {}", path, e);
-            return false;
-        }
+    // Create a file
+    if let Err(e) = touch(p) {
+        eprintln!("Error creating a file({}): {}", path, e);
+        return false;
     }
 
     true


### PR DESCRIPTION
This pull request refactors the `mkdir_touch` function in `src/main.rs` to simplify the logic for creating parent directories and files, and to improve error handling. The main improvements are a cleaner structure and more robust handling of edge cases.

Refactoring and error handling improvements:

* Simplified the logic for creating parent directories by always checking for a parent directory and ensuring it is non-empty before attempting to create it, regardless of whether the path contains a `/` character.
* Replaced `match` statements with `if let` error handling for both directory and file creation, making the code more concise and readable.